### PR TITLE
A-damW add seeed studio xiao ble nrf52840

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 This is code for the NRF52832 and the NRF52840 for communicating between the VESC and VESC Tool (linux and mobile) over BLE. After uploading the firmware, the NRF can be connected to the VESC using the RX and TX pins chosen in main.c, and the BLE scanner in VESC Tool should be able to find it and connect. Note that the UART port on the VESC must be enabled with a baud rate of 115200 for this to work. The NRF can also communicate with the VESC Remote at the same time as it runs BLE.  
 
-The code can be build with the NRF52 SDK by changing the path in Makefile. There is a variable in the makefile called IS_52832. If it is set to 1, the code is built for the NRF52832, otherwise it is built for the NRF52840. The difference between the two is which files are included from the NRF SDK and whether USB-CDC support is used in main.c. For now USB-CDC is only useful for printing debug information, but later it might be possible to connect VESC Tool over it.
+The code can be built with the NRF52 SDK by changing the SDK_ROOT path variable in Makefile to match the location of the NRF52 SDK on your system,
+download here: <https://www.nordicsemi.com/Products/Development-software/nRF5-SDK/Download>
+
+There is a variable in the makefile called IS_52832. If it is set to 1, the code is built for the NRF52832, otherwise it is built for the NRF52840. The difference between the two is which files are included from the NRF SDK and whether USB-CDC support is used in main.c. For now USB-CDC is only useful for printing debug information, but later it might be possible to connect VESC Tool over it.
 
 This is how to connect an STLINK V2 to the NRF52 for uploading the code:
 
@@ -12,6 +15,7 @@ This is how to connect an STLINK V2 to the NRF52 for uploading the code:
 | VDD           | 3.3V          |
 | SDO           | SWDIO         |
 | SCL           | SWCLK         |
+
 
 The first time the code is uploaded mass_erase must be run, and the softdevice must be uploaded. This can be done with the following make rules:
 
@@ -27,6 +31,12 @@ after that and after future changes only the code itself needs to be uploaded:
 
 ```bash
 make upload
+```
+
+alternatively, the firmware and softdevice can be compiled and merged with this command, and flashed via swd in VESC tool:
+
+```bash
+make merge_hex
 ```
 
 After the code is uploaded, the NRF52 can be connected to the VESC in the following way:

--- a/main.c
+++ b/main.c
@@ -68,8 +68,12 @@
 #include "esb_timeslot.h"
 #include "crc.h"
 
+#ifndef MODULE_XIAO_BLE
+#define MODULE_XIAO_BLE					1
+#endif
+
 #ifndef MODULE_BUILTIN
-#define MODULE_BUILTIN					1
+#define MODULE_BUILTIN					0
 #endif
 
 #ifndef MODULE_RD2
@@ -84,7 +88,9 @@
 #define USE_USB							0
 
 #ifdef NRF52840_XXAA
-#if MODULE_BUILTIN
+#if MODULE_XIAO_BLE
+#define DEVICE_NAME                     "Seeed Studio XIAO nRF52840"
+#elif MODULE_BUILTIN
 #define DEVICE_NAME                     "VESC 52840 BUILTIN"
 #elif MODULE_RD2
 #define DEVICE_NAME                     "VESC RAD2"
@@ -147,22 +153,34 @@ static pm_peer_id_t m_peer_to_be_deleted = PM_PEER_ID_INVALID;
 #define LED_ON()						nrf_gpio_pin_set(LED_PIN)
 #define LED_OFF()						nrf_gpio_pin_clear(LED_PIN)
 
+
 #ifdef NRF52840_XXAA
-#if MODULE_BUILTIN
+
+#if MODULE_XIAO_BLE
+#define UART_RX							NRF_GPIO_PIN_MAP(1, 12) //P1.12
+#define UART_TX							NRF_GPIO_PIN_MAP(1, 11) //P1.11
+#define UART_TX_DISABLED				2
+#define LED_PIN							NRF_GPIO_PIN_MAP(0, 30) //Green LED, P0.30
+								//NRF_GPIO_PIN_MAP(0, 6) //Blue LED, P0.06
+								//NRF_GPIO_PIN_MAP(0, 26) //Red LED, P0.26
+#elif MODULE_BUILTIN
 #define UART_RX							26
 #define UART_TX							25
 #define UART_TX_DISABLED				28
-#define LED_PIN							27
+#define LED_PIN						27
+
 #elif MODULE_RD2
 #define UART_RX							11
 #define UART_TX							12
 #define UART_TX_DISABLED				18
 #define LED_PIN							15
+
 #elif MODULE_STORMCORE
 #define UART_RX							31
 #define UART_TX							30
 #define UART_TX_DISABLED				29
 #define LED_PIN							5
+
 #elif MODULE_RD_BMS
 #define UART_RX							4
 #define UART_TX							5
@@ -172,12 +190,14 @@ static pm_peer_id_t m_peer_to_be_deleted = PM_PEER_ID_INVALID;
 #undef LED_OFF
 #define LED_ON()						nrf_gpio_pin_set(NRF_GPIO_PIN_MAP(1, 1)); nrf_gpio_pin_clear(LED_PIN)
 #define LED_OFF()						nrf_gpio_pin_set(LED_PIN)
+
 #else
 #define UART_RX							11
 #define UART_TX							8
 #define UART_TX_DISABLED				25
 #define LED_PIN							7
 #endif
+
 #else
 #if MODULE_BUILTIN
 #define UART_RX							6
@@ -186,6 +206,7 @@ static pm_peer_id_t m_peer_to_be_deleted = PM_PEER_ID_INVALID;
 #define EN_DEFAULT						1
 #define LED_PIN							8
 #define LED_PIN2_INV					5
+
 #else
 #define UART_RX							7
 #define UART_TX							6


### PR DESCRIPTION
I was able to get the Seeed Studio XIAO nRF52840 module working on my VESC controller, including the user RGB LED.
I have not tested everything extensively.
Tested so far:
I can connect to my controller over bluetooth(Android phone, 6.02 VESC moble app).
Change the name of the bluetooth adapter(default name: "Seeed Studio XIAO nRF52840", set in Main.c).
See battery pack voltage.
Change motor amperage limits.
Set user RGB LED to green (in Main.c) red and blue not tested yet.